### PR TITLE
chore(typescript-playground): ip-17 - abstract classes

### DIFF
--- a/pocs/typescript-playground/src/oop/circle.spec.ts
+++ b/pocs/typescript-playground/src/oop/circle.spec.ts
@@ -1,0 +1,49 @@
+import { Circle } from './circle'
+
+let sut : Circle
+
+const getSut = () : Circle => {
+    return new Circle(5)
+}
+
+beforeEach(() => {
+    sut = getSut()
+})
+
+afterEach(() => {
+    jest.restoreAllMocks()
+})
+
+describe('Circle', () => {
+    describe('radius', () => {
+        test('should be defined', () => {
+            expect(sut.radius).toBeDefined()
+        })
+
+        test('should equal 5', () => {
+            expect(sut.radius).toEqual(5)
+        })
+    })
+
+    describe('area', () => {
+        test('should be defined', () => {
+            expect(sut.area).toBeDefined()
+        })
+
+        test('should return area of circle', () => {
+            expect(sut.area()).toEqual(Math.PI * sut.radius * sut.radius)
+        })
+    })
+
+    describe('report', () => {
+        test('should be defined', () => {
+            expect(sut.report).toBeDefined()
+        })
+
+        test('should print radius, diameter, & area to std out', () => {
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined)
+            sut.report()
+            expect(logSpy).toHaveBeenCalledWith("Radius: 5, Diameter: 10, Area: 78.53981633974483")
+        })
+    })
+})

--- a/pocs/typescript-playground/src/oop/circle.ts
+++ b/pocs/typescript-playground/src/oop/circle.ts
@@ -1,0 +1,15 @@
+import { Shape } from './shape'
+
+export class Circle extends Shape {
+    constructor(public radius: number) {
+        super()
+    }
+    
+    area(): number {
+        return Math.PI * this.radius * this.radius
+    }
+
+    public report(): void {
+        console.log(`Radius: ${this.radius}, Diameter: ${this.radius * 2}, Area: ${this.area()}`)
+    }
+}

--- a/pocs/typescript-playground/src/oop/shape.ts
+++ b/pocs/typescript-playground/src/oop/shape.ts
@@ -1,0 +1,3 @@
+export abstract class Shape {
+    abstract area(): number;
+}


### PR DESCRIPTION
# Issue
Closes #17 

# Changes
- Implements the abstract `Shape` class in `shape.ts`
    - Includes the `area(): number` method
- Concrete class `Circle` that extends the `Shape` class in `circle.ts` 
    - Includes the class-specific `area(): number` method
    - Implements the `public report(): void` method that prints the radius, diameter, and area of the object to std out
- Unit tests for the `Circle` class in `circle.spec.ts`